### PR TITLE
Fix missing config in Passport handler request

### DIFF
--- a/lib/PassportHandler.js
+++ b/lib/PassportHandler.js
@@ -257,7 +257,7 @@ export class PassportHandler {
             config.headers.Cookie = this.loginSession.getPassportCookieString();
         }
 
-        const res = await client.get(authenticationServerUrl, { headers: { Authorization: requestMessage } });
+        const res = await client.get(authenticationServerUrl, config);
 
         return this.handleAuthenticationServerResponse(res);
     }


### PR DESCRIPTION
## Summary
- use the prepared Axios configuration when sending Authorization requests
- update npm dependencies to run tests (nothing in repo changed)

## Testing
- `npm run test:local`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_6841cbf5607c8324b1b767084b9f2d51