### PR TITLE
Fix sendResponse usage and typo

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -189,8 +189,8 @@ export class Server {
 
                     if (req.__bodyCache.cacheOverflow) {
                         // Cannot repeat request
-                        sendResponse(proxyRes, req, res, 503,
-                            'Passport authentication was successfull, but the proxy server cannot repeat the original'
+                        this.sendResponse(proxyRes, req, res, 503,
+                            'Passport authentication was successful, but the proxy server cannot repeat the original'
                             + ' client request with authorization because the client request body length exceeds the'
                             + ` request body cache size of ${RequestBodyCache.getMaxCacheSize()} KiB. Please repeat the`
                             + ' request.');


### PR DESCRIPTION
## Summary
- fix grammar 'successful'
- call `this.sendResponse` to use method correctly

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: ONEDRIVE environment variables not set)*
- `npm run test:local`

------
https://chatgpt.com/codex/tasks/task_e_6841cd52e0e08324a70c309b1c8c3d20