### PR TITLE
Fix config in passport handler and test cookies

### DIFF
--- a/test/local/index.js
+++ b/test/local/index.js
@@ -7,7 +7,11 @@ import { assert } from 'chai';
 import {AuthHeader} from '../../lib/AuthHeader.js';
 import {partnerServer} from './passport_servers/partnerServer.js';
 import {configurationServer} from './passport_servers/configurationServer.js';
-import {authenticationServer} from './passport_servers/authenticationServer.js';
+import {
+    authenticationServer,
+    receivedCookieHeaders,
+    clearReceivedCookieHeaders,
+} from './passport_servers/authenticationServer.js';
 import {config} from './passport_servers/config.js';
 import {userlist} from './passport_servers/users.js';
 
@@ -48,6 +52,8 @@ describe('local tests with mock servers', () => {
 
     let proxyServerChild;
     beforeEach('Start proxy server', (done) => {
+        clearReceivedCookieHeaders();
+
         const env = { ...process.env };
         env.CONFIGURATION_SERVER_URL = config.CONFIGURATION_SERVER_URL;
         env.PROXY_TARGET = config.PARTNER_SERVER_URL;
@@ -130,6 +136,9 @@ describe('local tests with mock servers', () => {
         res = await client.get(directoryB, { auth: { username: usernameA, password: passwordA } });
         assert.strictEqual(res.status, 401, 'HTTP status code is not 401');
         assert.isNull(res.data, 'Response has content, but no content was expected');
+
+        const lastCookie = receivedCookieHeaders[receivedCookieHeaders.length - 2];
+        assert.strictEqual(lastCookie, 'auth=' + directoryA, 'Authentication server did not receive cookie header');
     });
 
     after('Stop authentication server', (done) => {

--- a/test/local/passport_servers/authenticationServer.js
+++ b/test/local/passport_servers/authenticationServer.js
@@ -4,6 +4,11 @@ import { AuthHeader } from '../../../lib/AuthHeader.js';
 import { parsePassportParameters } from '../../../lib/parsePassportParameters.js';
 import { getUserdata } from './users.js';
 
+export const receivedCookieHeaders = [];
+export function clearReceivedCookieHeaders() {
+    receivedCookieHeaders.length = 0;
+}
+
 function send401(res) {
     res.setHeader('WWW-Authenticate', 'Passport1.4 da-status=failed,srealm=PassportTest,ctoken=abc');
     res.writeHead(401);
@@ -13,6 +18,8 @@ function send401(res) {
 // eslint-disable-next-line consistent-return
 export const authenticationServer = createServer((req, res) => {
     res.setHeader('PassportConfig', 'ConfigVersion=1');
+
+    receivedCookieHeaders.push(req.headers.cookie || null);
 
     const authorizationHeader = new AuthHeader(req.headers.authorization);
 


### PR DESCRIPTION
## Summary
- ensure cookies tracking in test servers
- clear cookies before each test
- validate the cookie header is sent to the authentication server

## Testing
- `npm run test:local`
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm test` *(fails: OneDrive litmus env vars missing)*

------
https://chatgpt.com/codex/tasks/task_e_6841ce07b5008324b90c3374645bb8a3