### PR TITLE
Ensure cookies included in auth server requests

### DIFF
--- a/lib/PassportHandler.js
+++ b/lib/PassportHandler.js
@@ -254,7 +254,10 @@ export class PassportHandler {
         const config = { headers: { Authorization: requestMessage } };
 
         if (addCookies) {
-            config.headers.Cookie = this.loginSession.getPassportCookieString();
+            const cookieString = this.loginSession.getPassportCookieString();
+            if (cookieString) {
+                config.headers.Cookie = cookieString;
+            }
         }
 
         const res = await client.get(authenticationServerUrl, config);

--- a/test/local/index.js
+++ b/test/local/index.js
@@ -111,6 +111,27 @@ describe('local tests with mock servers', () => {
         assert.strictEqual(res.data, content, 'Did not receive the expected content');
     });
 
+    it('should send stored cookies to the authentication server', async () => {
+        const {
+            username: usernameA,
+            password: passwordA,
+            directory: directoryA,
+        } = userlist[0];
+
+        const { directory: directoryB } = userlist[1];
+
+        await client.get(directoryA, { auth: { username: usernameA, password: passwordA } });
+
+        assert.isNull(receivedCookieHeaders[0], 'Initial Token Request contains Cookie header');
+        assert.isNull(receivedCookieHeaders[1], 'Initial Sign-in Request contains Cookie header');
+
+        await client.get(directoryB, { auth: { username: usernameA, password: passwordA } });
+
+        const lastCookie = receivedCookieHeaders[receivedCookieHeaders.length - 2];
+        assert.strictEqual(lastCookie, 'auth=' + directoryA,
+            'Authentication server did not receive cookie header');
+    });
+
     it('should not allow user A to access content of user B', async () => {
         const {
             username: usernameA,


### PR DESCRIPTION
## Summary
- add cookie value only when present in `sendAuthorizationRequestMessage`
- extend local tests to verify cookie headers are sent to the authentication server

## Testing
- `npm run test:local`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6841cff3a0288324b7d55dee3f537dbc