### PR TITLE
Add docker-compose configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+services:
+  passport-proxy:
+    build: .
+    container_name: passport-proxy
+    ports:
+      - "3000:3000"
+    environment:
+      PROXY_TARGET: https://d.docs.live.net/
+      PROXY_PORT: 3000
+    restart: always


### PR DESCRIPTION
## Summary
- add a `docker-compose.yml` for easy container startup

## Testing
- `npm run test:local`
- `npm test` *(fails: missing OneDrive env vars)*
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6841d98d9ac08324acd781b365c6ba13